### PR TITLE
Fix bug. Allow to fetch tickets (of type actAsType:customer) using th…

### DIFF
--- a/API/Tickets.php
+++ b/API/Tickets.php
@@ -27,14 +27,15 @@ class Tickets extends Controller
         $entityManager = $this->getDoctrine()->getManager();
         $ticketRepository = $this->getDoctrine()->getRepository('UVDeskCoreFrameworkBundle:Ticket');
         $userRepository = $this->getDoctrine()->getRepository('UVDeskCoreFrameworkBundle:User');
-
+        
         if ($request->query->get('actAsType')) {    
             switch($request->query->get('actAsType')) {
-                case 'customer': 
-                    $customer = $entityManager->getRepository('UVDeskCoreFrameworkBundle:User')->findOneByEmail($data['actAsEmail']);
+                case 'customer':
+                    $email = $request->query->get('actAsEmail');
+                    $customer = $entityManager->getRepository('UVDeskCoreFrameworkBundle:User')->findOneByEmail($email);
 
                     if ($customer) {
-                        $json = $repository->getAllCustomerTickets($request->query, $this->container, $customer);
+                        $json = $ticketRepository->getAllCustomerTickets($request->query, $this->container, $customer);
                     } else {
                         $json['error'] = $this->get('translator')->trans('Error! Resource not found.');
                         return new JsonResponse($json, Response::HTTP_NOT_FOUND);


### PR DESCRIPTION
<!--
Thank you for contributing to UVDesk! Please fill out this description template to help us to process your pull request.
-->

### 1. Why is this change necessary?
There's a bug, so when you try to follow the API  instructions, in order to fetch tickets, 
you can't fetch tickets based on a particular customer email.


### 2. What does this change do, exactly?
The code below has some problems, I guess: 
```php
 $customer = $entityManager->getRepository('UVDeskCoreFrameworkBundle:User')->findOneByEmail($data['actAsEmail']);
  if ($customer) {
      $json = $repository->getAllCustomerTickets($request->query, $this->container, $customer);
  }
```

The first line: 

```php
 $customer = $entityManager->getRepository('UVDeskCoreFrameworkBundle:User')->findOneByEmail($data['actAsEmail']);
```

Should be:

```php
$email = $request->query->get('actAsEmail');
$customer = $entityManager->getRepository('UVDeskCoreFrameworkBundle:User')->findOneByEmail($email);
```

Because the API should be expecting the get query params.

The third line: 
```php
$json = $repository->getAllCustomerTickets($request->query, $this->container, $customer);
```

Should be:
```php
$json = $ticketRepository->getAllCustomerTickets($request->query, $this->container, $customer);
```

because $repository is not defined. I guess we want to access the $ticketRepository to get the customers.


### 3. Please link to the relevant issues (if any).
I opened a issue here: https://github.com/uvdesk/api-bundle/issues/16

It should be mentioned that if you try to filter by agent, that is still not working. 
If you try this endpoint: {my_localhost_url}/api/v1/tickets?actAsEmail={agent@agentemail.com}&actAsType=agent
The API returns:

```json
{
    "status": false,
    "message": "An unexpected error occurred. Please try again later."
}
```

So I guess there's a problem with this line: 
```php
$user = $entityManager->getRepository('UVDeskCoreFrameworkBundle:User')->findOneByEmail($data['actAsEmail']);
```
You could change $data['actAsEmail'] by $request->query->get('actAsEmail') and the error disappear.
The problem is that after that, if we try to filter by agent email the API returns all the tickets everytime.

